### PR TITLE
pre-commit: remove no-commit-to-branch hook

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -15,8 +15,6 @@ repos:
   - id: forbid-submodules
   - id: mixed-line-ending
     args: [--fix=lf]
-  - id: no-commit-to-branch
-    args: [--branch=main]
   - id: trailing-whitespace
 - repo: https://github.com/Lucas-C/pre-commit-hooks
   rev: v1.5.5


### PR DESCRIPTION
The `no-commit-to-branch` hook would fail when run on the `main` branch even if the `hook-stage` was `manual` or `post-commit`. As a result, pre-commit would always fail on the main branch in GHA.